### PR TITLE
Implement deserialization of V2 JSON

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths   ["src"]
- :deps    {}
+ :deps    {metosin/jsonista {:mvn/version "0.3.1"}}
  :aliases {:pack
            {:extra-deps {pack/pack.alpha
                          {:git/url "https://github.com/juxt/pack.alpha.git"


### PR DESCRIPTION
We provide a `parse-events!` fn and `event-map->record` multimethod
which is compatible with the JSON serialized output of the V2 alda CLI
client.